### PR TITLE
Focus to textarea immediately in all scenarios and disable submit on submission

### DIFF
--- a/js/pmm-init.js
+++ b/js/pmm-init.js
@@ -175,6 +175,20 @@
   };
 
   /**
+   * Disable submit button.
+   */
+  Drupal.pmm.helpers.disableSubmitButton = function() {
+    $('.pmm-thread__send').addClass('disabled');
+  };
+
+  /**
+   * Enable submit button.
+   */
+  Drupal.pmm.helpers.enableSubmitButton = function() {
+    $('.pmm-thread__send').removeClass('disabled');
+  };
+
+  /**
    * Return the unix timestamp for the last visible message in the current thread.
    */
   Drupal.pmm.helpers.getLastVisibleMsgTimeStamp = function() {
@@ -192,11 +206,19 @@
     $(window).trigger('pm:threads:viewed');
     var $msg = $('textarea', $form), values = $form.serialize();
     if ($msg.val() == '' || $('.pmm-member', $form).length === 0) {
+      $('.pmm-thread__message-text textarea').focus();
       return;
     }
+
+    // Don't submit when button is disabled (prevents double submission).
+    if ($('.pmm-thread__send').hasClass('disabled')) {
+      return;
+    }
+
     // Get time of last po
     values += '&timestamp=' + Drupal.pmm.helpers.getLastVisibleMsgTimeStamp();
     // Post & Save.
+    $msg.val('');
     $.post(Drupal.pmm.helpers.buildReqUrl('message', {}, 'post'), values, function(data) {
       if (data && data.thread) {
         $msg.val('');

--- a/js/pmm-thread.js
+++ b/js/pmm-thread.js
@@ -111,14 +111,24 @@
         var $thread = Drupal.pmm.views.threadInstance.render().$el;
         $('#pmm-thread').html($thread);
 
+        // Focus to textarea.
+        $('.pmm-thread__message-text textarea').focus();
+
         // Bind form submit to save a new message.
         Drupal.pmm.views.threadInstance.on('form:submit', function(item, event){
           Drupal.pmm.helpers.saveMessage($('form', item.$el), function(data){
+            // Disable form submit button.
+            Drupal.pmm.helpers.disableSubmitButton();
+
             // Add new messages to collection and scroll to it.
             Drupal.pmm.collections.messagesInstance.add(data.messages);
             Drupal.pmm.helpers.scrollThreadToLastMsg();
+
             // Refresh sidebar.
             Drupal.pmm.collections.threadsInstance.fetch();
+
+            // Enable form submit button.
+            Drupal.pmm.helpers.enableSubmitButton();
           });
         });
       });
@@ -141,6 +151,9 @@
       // Render it to the dom.
       var $threadNew = Drupal.pmm.views.threadNewInstance.render().$el;
       $('#pmm-thread').html($threadNew);
+
+      // Focus to textarea.
+      $('.pmm-thread__message-text textarea').focus();
 
       // Bind form submit to save a new message.
       Drupal.pmm.views.threadNewInstance.on('form:submit', function(item, event){

--- a/js/pmm-threads.js
+++ b/js/pmm-threads.js
@@ -18,6 +18,7 @@
         Drupal.pmm.views.threadListInstance.on('childview:select:item', function(item, event){
           Drupal.pmm.helpers.navigateTo(item.model.get('id'));
           $(window).trigger('pm:threads:viewed');
+          $('.pmm-thread__message-text textarea').focus();
         });
 
         // Set the optional uid so new users appear in thread list.


### PR DESCRIPTION
Just wanted to contribute back with these changes and improve overall UX. It has simple changes - focus on textarea immediately after clicking thread or starting new thread.

Also, has some protection from double posting same message. Let me know if you think this has to be modified. I'm willing to discuss how it should be properly implemented. Cheers!